### PR TITLE
fix(main.yaml): Throttle to 8 when adding repos from RPMs

### DIFF
--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -47,6 +47,7 @@
   loop: "{{ additional_repos }}"
 
 - name: "Add repos from rpms"
+  throttle: 8
   yum:
     name: "{{ item.from_rpm }}"
     state: present


### PR DESCRIPTION
We're experiencing memory issues when the concurrency is high, so let's try playing safe at the playbook level.